### PR TITLE
Navbar breakpoints restored

### DIFF
--- a/client/less/lib/bootstrap/variables.less
+++ b/client/less/lib/bootstrap/variables.less
@@ -289,7 +289,7 @@
 
 // Medium screen / desktop
 //** Deprecated `@screen-md` as of v3.0.1
-@screen-md:                  1031px;
+@screen-md:                  992px;
 @screen-md-min:              @screen-md;
 //** Deprecated `@screen-desktop` as of v3.0.1
 @screen-desktop:             @screen-md-min;

--- a/client/less/main.less
+++ b/client/less/main.less
@@ -461,12 +461,6 @@ thead {
   width: 50px;
 }
 
-.brownie-points-nav {
-  @media (min-width: 991px) and (max-width: 999px) {
-    margin-right: -10px;
-  }
-}
-
 .navbar-nav a {
   color: @body-bg;
   font-size: 20px;


### PR DESCRIPTION
we'd changed it to fit jobs, but it's not required anymore. this restores the original 992px.

Also, fix for avatar spacing to brownie points when at that point.